### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -41,11 +41,6 @@ jobs:
               uses: pnpm/action-setup@v4
               with:
                 version: 9.14.4
-            - name: Setup Github Credentials
-              run: |
-                  git config --global user.name "${{ github.actor }}"
-                  git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-                  git remote set-url origin https://${{ github.actor }}:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
             - name: Create Release
               uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
remove setting up git credentials